### PR TITLE
Document client-side XRPC query workarounds pending AppView

### DIFF
--- a/src/atdata/atmosphere/client.py
+++ b/src/atdata/atmosphere/client.py
@@ -533,6 +533,13 @@ class Atmosphere:
         return records, response.cursor
 
     # Convenience methods for atdata collections
+    #
+    # These thin wrappers call list_records() which maps to
+    # com.atproto.repo.listRecords — a generic PDS endpoint.
+    # They return at most `limit` records with no automatic pagination.
+    # When a dedicated AppView with collection-specific listing endpoints
+    # is available, these should be updated to use those endpoints for
+    # proper server-side pagination and filtering.
 
     def list_schemas(
         self,
@@ -543,7 +550,8 @@ class Atmosphere:
 
         Args:
             repo: The DID to query. Defaults to authenticated user.
-            limit: Maximum number to return.
+            limit: Maximum number to return.  No automatic pagination;
+                repositories with more records return a truncated result.
 
         Returns:
             List of schema records.
@@ -564,7 +572,8 @@ class Atmosphere:
 
         Args:
             repo: The DID to query. Defaults to authenticated user.
-            limit: Maximum number to return.
+            limit: Maximum number to return.  No automatic pagination;
+                repositories with more records return a truncated result.
 
         Returns:
             List of dataset records.
@@ -585,7 +594,8 @@ class Atmosphere:
 
         Args:
             repo: The DID to query. Defaults to authenticated user.
-            limit: Maximum number to return.
+            limit: Maximum number to return.  No automatic pagination;
+                repositories with more records return a truncated result.
 
         Returns:
             List of lens records.
@@ -606,7 +616,8 @@ class Atmosphere:
 
         Args:
             repo: The DID to query. Defaults to authenticated user.
-            limit: Maximum number to return.
+            limit: Maximum number to return.  No automatic pagination;
+                repositories with more records return a truncated result.
 
         Returns:
             List of label records.

--- a/src/atdata/atmosphere/records.py
+++ b/src/atdata/atmosphere/records.py
@@ -480,6 +480,11 @@ class DatasetLoader:
     ) -> list[dict]:
         """List dataset records from a repository.
 
+        This delegates to ``com.atproto.repo.listRecords`` which returns at
+        most ``limit`` records with no automatic pagination.  Repositories
+        with more dataset records than ``limit`` will return a truncated
+        result.
+
         Args:
             repo: The DID of the repository. Defaults to authenticated user.
             limit: Maximum number of records to return.

--- a/src/atdata/atmosphere/schema.py
+++ b/src/atdata/atmosphere/schema.py
@@ -199,6 +199,16 @@ class SchemaLoader:
     This class fetches schema records from ATProto and can list available
     schemas from a repository.
 
+    Note:
+        The ``ac.foundation.dataset.getLatestSchema`` query lexicon is
+        defined but has no AppView to serve it yet. A client-side
+        equivalent (fetching all schema records and picking the latest
+        version) has not been implemented here. When the AppView ships,
+        add a ``resolve()``-style method backed by
+        ``GET /xrpc/ac.foundation.dataset.getLatestSchema``.
+        See also: ``LabelLoader.resolve()`` for the label workaround
+        pattern.
+
     Examples:
         >>> atmo = Atmosphere.login("handle", "password")
         >>>
@@ -258,6 +268,11 @@ class SchemaLoader:
         limit: int = 100,
     ) -> list[dict]:
         """List schema records from a repository.
+
+        This delegates to ``com.atproto.repo.listRecords`` which returns at
+        most ``limit`` records with no automatic pagination.  Repositories
+        with more schema records than ``limit`` will return a truncated
+        result.
 
         Args:
             repo: The DID of the repository. Defaults to authenticated user.


### PR DESCRIPTION
## Summary
- Documents client-side XRPC query workarounds in the atmosphere module (GH #45)
- Adds docstrings and inline comments noting temporary `list_records()` + filter patterns
- References corresponding lexicon NSIDs and known limitations

## Changes
- `atmosphere/labels.py` — documented `LabelLoader.resolve()` workaround
- `atmosphere/schema.py` — documented schema resolution workaround
- `atmosphere/records.py`, `atmosphere/lens.py`, `atmosphere/client.py` — additional documentation
- No logic changes — documentation only (5 files, +100/-4)

## Test plan
- [ ] Verify all tests still pass (no logic changes)
- [ ] Review docstrings for accuracy

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)