### PR TITLE
Add E2E tests for ATProto session management

### DIFF
--- a/tests/integration/test_session_management.py
+++ b/tests/integration/test_session_management.py
@@ -36,9 +36,7 @@ class TestSessionLogin:
         assert atmo.did.startswith("did:plc:")
         assert atmo.handle == handle
 
-    def test_login_populates_did_and_handle(
-        self, atproto_credentials: tuple[str, str]
-    ):
+    def test_login_populates_did_and_handle(self, atproto_credentials: tuple[str, str]):
         """Login populates both did and handle with non-empty strings."""
         handle, password = atproto_credentials
         atmo = Atmosphere.login(handle, password)
@@ -63,9 +61,7 @@ class TestSessionExportImport:
         assert isinstance(session_str, str)
         assert len(session_str) > 0
 
-    def test_session_roundtrip_preserves_identity(
-        self, atproto_client: Atmosphere
-    ):
+    def test_session_roundtrip_preserves_identity(self, atproto_client: Atmosphere):
         """Exported session can be used to create a new client with same identity."""
         session_str = atproto_client.export_session()
 
@@ -74,9 +70,7 @@ class TestSessionExportImport:
         assert atmo2.did == atproto_client.did
         assert atmo2.handle == atproto_client.handle
 
-    def test_reimported_client_can_export_again(
-        self, atproto_client: Atmosphere
-    ):
+    def test_reimported_client_can_export_again(self, atproto_client: Atmosphere):
         """A client created from an imported session can re-export."""
         session1 = atproto_client.export_session()
 


### PR DESCRIPTION
## Summary
- Adds end-to-end integration tests for ATProto session management flows (GH #36)
- Covers login, session export/import round-trip, unauthenticated reads, and error cases

## Changes
- New `tests/integration/test_session_management.py` (192 lines)
- 2 commits: initial tests + ADR review refinements (reduced PDS logins, tightened assertions)

## Test plan
- [ ] Verify tests parse correctly (`uv run pytest --collect-only tests/integration/test_session_management.py`)
- [ ] Integration tests run in CI with ATProto credentials

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)