### PR TITLE
feat: connect atmosphere label system to Index write/load paths

### DIFF
--- a/src/atdata/index/_index.py
+++ b/src/atdata/index/_index.py
@@ -1144,9 +1144,11 @@ class Index:
                     dataset_uri = atmo.resolve_label(handle_or_did, resolved_ref)
                     return atmo.get_dataset(dataset_uri)
                 except KeyError:
-                    pass  # fall through to error below
-                except Exception:
-                    pass  # network/SDK errors treated as "not found"
+                    raise
+                except Exception as exc:
+                    raise KeyError(
+                        f"Cannot resolve {ref!r} on atmosphere: {exc}"
+                    ) from exc
             raise KeyError(
                 f"Cannot resolve {ref!r} on atmosphere. No label found. "
                 "Use an AT URI or ensure a label exists for @handle/name."

--- a/tests/test_repository_coverage.py
+++ b/tests/test_repository_coverage.py
@@ -68,12 +68,16 @@ def test_ensure_loaders_lazy_init(backend) -> None:
     """Loaders/publishers are None until _ensure_loaders is called."""
     assert backend._schema_loader is None
     assert backend._dataset_loader is None
+    assert backend._label_publisher is None
+    assert backend._label_loader is None
 
     with (
         patch("atdata.atmosphere.schema.SchemaPublisher") as MockSP,
         patch("atdata.atmosphere.schema.SchemaLoader") as MockSL,
         patch("atdata.atmosphere.records.DatasetPublisher") as MockDP,
         patch("atdata.atmosphere.records.DatasetLoader") as MockDL,
+        patch("atdata.atmosphere.labels.LabelPublisher") as MockLP,
+        patch("atdata.atmosphere.labels.LabelLoader") as MockLL,
     ):
         backend._ensure_loaders()
 
@@ -81,6 +85,8 @@ def test_ensure_loaders_lazy_init(backend) -> None:
         MockSL.assert_called_once_with(backend.client)
         MockDP.assert_called_once_with(backend.client)
         MockDL.assert_called_once_with(backend.client)
+        MockLP.assert_called_once_with(backend.client)
+        MockLL.assert_called_once_with(backend.client)
 
     # Second call is a no-op (already initialised)
     backend._ensure_loaders()


### PR DESCRIPTION
## Summary

- `_AtmosphereBackend.insert_dataset()` now publishes a label record alongside the dataset record, enabling `@handle/name` resolution
- `Index.get_label()` and `Index.get_dataset()` route `@handle/name` paths through atmosphere label resolution
- `_AtmosphereBackend` lazily initializes `LabelPublisher` and `LabelLoader` in `_ensure_loaders()`

## ADR fixes included

- Replaced bare `except Exception: pass` in `get_dataset()` with proper exception chaining
- Made label publish best-effort in `insert_dataset()` — logs warning on failure instead of losing the already-created dataset record
- Added label publisher/loader assertions to `test_ensure_loaders_lazy_init`
- Added tests for bare `@foo` path and SDK error chaining in `get_dataset()`

## Test plan

- [x] 41 new/updated tests in `test_atmosphere_label_integration.py` and `test_repository_coverage.py`
- [x] Full suite: 1594 passed, 0 failures
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)