### PR TITLE
feat: unified search API with pluggable backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Handle-based schema resolution**: `get_schema()` and `get_schema_type()` now accept `@handle/TypeName@version` format, resolving schemas by handle + name + optional semver instead of requiring raw AT-URIs (GH#61)
 
 ### Changed
+- Unified Search API with Pluggable Backends (#833)
+- Phase 7: Export public API and lint/test pass (#840)
+- Phase 6: Comprehensive tests (#839)
+- Phase 5: Index.search() integration (#838)
+- Phase 4: SearchAggregator (#837)
+- Phase 3: LocalSearchBackend implementation (#836)
+- Phase 2: AppViewSearchBackend implementation (#835)
+- Phase 1: Search types and SearchBackend protocol (#834)
 - **AppView-aware loaders/publishers**: `SchemaLoader`, `LabelLoader`, `DatasetLoader`, `LensLoader` and their corresponding publishers now prefer AppView XRPC endpoints when configured, with automatic graceful fallback to client-side `com.atproto.repo` workarounds (GH#50)
 - **`load_dataset()` atmosphere parameter**: New optional `atmosphere` kwarg passes an `Atmosphere` client (and its AppView) through to AT URI resolution (GH#50)
 - **Namespace rename**: Lexicon namespace renamed from `ac.foundation.dataset` to `science.alt.dataset` across all source, tests, and documentation. Lexicon JSON files vendored from [forecast-bio/atdata-lexicon](https://github.com/forecast-bio/atdata-lexicon) with NSID-to-path directory structure. Lexicon loader updated to resolve NSIDs via path traversal. Added `label` and `resolveLabel` to `LEXICON_IDS` (GH#71)

--- a/src/atdata/__init__.py
+++ b/src/atdata/__init__.py
@@ -119,6 +119,15 @@ from ._cid import (
     verify_cid as verify_cid,
 )
 
+from .search import (
+    SearchResult as SearchResult,
+    SearchResults as SearchResults,
+    SearchBackend as SearchBackend,
+    AppViewSearchBackend as AppViewSearchBackend,
+    LocalSearchBackend as LocalSearchBackend,
+    SearchAggregator as SearchAggregator,
+)
+
 from .promote import (
     promote_to_atmosphere as promote_to_atmosphere,
 )

--- a/src/atdata/index/_index.py
+++ b/src/atdata/index/_index.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from atdata.repository import Repository, _AtmosphereBackend
     from atdata._protocols import IndexEntry
     from atdata.lens import Lens
+    from atdata.search import SearchResults
 
 T = TypeVar("T", bound=Packable)
 
@@ -1936,3 +1937,64 @@ class Index:
             record["$ref"] = f"atdata://local/lens/{name}@{version}"
             records.append(record)
         return records
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        text: str | None = None,
+        tags: list[str] | None = None,
+        schema_ref: str | None = None,
+        repo: str | None = None,
+        limit: int = 50,
+        include_atmosphere: bool = True,
+    ) -> "SearchResults":
+        """Search datasets across local and atmosphere backends.
+
+        Queries the local index and, optionally, the AppView, then merges
+        and deduplicates the results.  If the atmosphere backend is
+        unavailable or unhealthy the search degrades gracefully to
+        local-only results.
+
+        Args:
+            text: Free-text query string (substring match for local,
+                full-text for AppView).
+            tags: Filter by tags.
+            schema_ref: Filter by schema reference.
+            repo: Filter by repository DID or handle (atmosphere only).
+            limit: Maximum total results.
+            include_atmosphere: If ``True`` (default), include atmosphere
+                results when an AppView is configured.
+
+        Returns:
+            :class:`~atdata.search.SearchResults` with merged items.
+
+        Examples:
+            >>> index = Index()
+            >>> results = index.search(text="mnist")
+            >>> for r in results.items:
+            ...     print(r.name, r.source)
+        """
+        from atdata.search import (
+            AppViewSearchBackend,
+            LocalSearchBackend,
+            SearchAggregator,
+        )
+
+        backends: list = [LocalSearchBackend(self)]
+
+        if include_atmosphere:
+            atmo = self._get_atmosphere()
+            if atmo is not None and atmo.client.has_appview:
+                backends.append(AppViewSearchBackend(atmo.client))
+
+        aggregator = SearchAggregator(backends)
+        return aggregator.search(
+            text=text,
+            tags=tags,
+            schema_ref=schema_ref,
+            repo=repo,
+            limit=limit,
+        )

--- a/src/atdata/search.py
+++ b/src/atdata/search.py
@@ -1,0 +1,454 @@
+"""Unified search API with pluggable backends.
+
+Provides a ``SearchBackend`` protocol for pluggable search providers, concrete
+implementations for the AppView (``AppViewSearchBackend``) and local index
+(``LocalSearchBackend``), and a ``SearchAggregator`` that merges and
+deduplicates results from multiple backends.
+
+Examples:
+    >>> from atdata.search import LocalSearchBackend, SearchAggregator
+    >>> backend = LocalSearchBackend(index)
+    >>> results = backend.search(text="mnist")
+    >>> for r in results.items:
+    ...     print(r.name, r.source)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from atdata._logging import get_logger
+
+
+# ------------------------------------------------------------------ #
+# Result types
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class SearchResult:
+    """A single search result from any backend.
+
+    Attributes:
+        uri: AT-URI or local identifier (e.g. CID).
+        name: Human-readable dataset name.
+        description: Optional description.
+        tags: Tags associated with the dataset.
+        schema_ref: Schema reference, if available.
+        source: Backend name that produced this result
+            (e.g. ``"local"``, ``"atmosphere"``).
+        score: Relevance score (if the backend provides one).
+        record: Raw record data, if available.
+    """
+
+    uri: str
+    name: str
+    description: str | None = None
+    tags: list[str] = field(default_factory=list)
+    schema_ref: str | None = None
+    source: str = "unknown"
+    score: float | None = None
+    record: dict | None = None
+
+
+@dataclass
+class SearchResults:
+    """Paginated collection of search results.
+
+    Attributes:
+        items: The list of results for this page.
+        cursor: Opaque cursor for fetching the next page, or ``None``
+            if there are no more results.
+        total_hint: Estimated total number of matching results across
+            all pages (may be ``None`` if the backend doesn't provide it).
+        source: Describes which backend(s) contributed
+            (e.g. ``"local"``, ``"atmosphere"``, ``"aggregated"``).
+    """
+
+    items: list[SearchResult] = field(default_factory=list)
+    cursor: str | None = None
+    total_hint: int | None = None
+    source: str = "unknown"
+
+
+# ------------------------------------------------------------------ #
+# SearchBackend protocol
+# ------------------------------------------------------------------ #
+
+
+@runtime_checkable
+class SearchBackend(Protocol):
+    """Interface for pluggable search backends.
+
+    Implementations must provide a ``name`` property, a ``search`` method
+    returning ``SearchResults``, and a ``health_check`` method.
+
+    Examples:
+        >>> class MyBackend:
+        ...     @property
+        ...     def name(self) -> str:
+        ...         return "custom"
+        ...     def search(self, text=None, **kw) -> SearchResults:
+        ...         return SearchResults(items=[], source="custom")
+        ...     def health_check(self) -> bool:
+        ...         return True
+    """
+
+    @property
+    def name(self) -> str:
+        """Backend identifier (e.g. ``"appview"``, ``"local"``)."""
+        ...
+
+    def search(
+        self,
+        text: str | None = None,
+        tags: list[str] | None = None,
+        schema_ref: str | None = None,
+        repo: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SearchResults:
+        """Search for datasets matching the given criteria.
+
+        Args:
+            text: Free-text query string.
+            tags: Filter by tags (all must match).
+            schema_ref: Filter by schema reference.
+            repo: Filter by repository DID or handle.
+            limit: Maximum number of results to return.
+            cursor: Pagination cursor from a previous ``SearchResults``.
+
+        Returns:
+            A ``SearchResults`` with matching items.
+        """
+        ...
+
+    def health_check(self) -> bool:
+        """Return ``True`` if this backend is reachable and operational."""
+        ...
+
+
+# ------------------------------------------------------------------ #
+# AppView search backend
+# ------------------------------------------------------------------ #
+
+
+class AppViewSearchBackend:
+    """Search backend that delegates to an AppView's XRPC endpoints.
+
+    Wraps :meth:`Atmosphere.xrpc_query` for the
+    ``science.alt.dataset.searchDatasets`` endpoint and returns standardized
+    ``SearchResults``.
+
+    Args:
+        atmosphere: An ``Atmosphere`` instance with an AppView configured.
+
+    Examples:
+        >>> from atdata.atmosphere.client import Atmosphere
+        >>> atmo = Atmosphere(appview="https://datasets.atdata.blue")
+        >>> backend = AppViewSearchBackend(atmo)
+        >>> results = backend.search(text="genomics")
+    """
+
+    def __init__(self, atmosphere: Any) -> None:
+        self._atmo = atmosphere
+
+    @property
+    def name(self) -> str:
+        """Backend identifier."""
+        return "atmosphere"
+
+    def search(
+        self,
+        text: str | None = None,
+        tags: list[str] | None = None,
+        schema_ref: str | None = None,
+        repo: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SearchResults:
+        """Search datasets via the AppView ``searchDatasets`` XRPC endpoint.
+
+        Args:
+            text: Free-text query string.
+            tags: Filter by tags.
+            schema_ref: Filter by schema reference.
+            repo: Filter by repository DID or handle.
+            limit: Maximum results (capped at 100 by the AppView).
+            cursor: Pagination cursor.
+
+        Returns:
+            ``SearchResults`` with atmosphere-sourced items.
+
+        Raises:
+            AppViewRequiredError: If no AppView is configured.
+            AppViewUnavailableError: If the AppView is unreachable.
+        """
+        from atdata.atmosphere._types import LEXICON_NAMESPACE
+
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if text is not None:
+            params["q"] = text
+        if tags is not None:
+            params["tags"] = tags
+        if schema_ref is not None:
+            params["schemaRef"] = schema_ref
+        if repo is not None:
+            params["repo"] = repo
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        result = self._atmo.xrpc_query(
+            f"{LEXICON_NAMESPACE}.searchDatasets", params=params
+        )
+
+        items: list[SearchResult] = []
+        for entry in result.get("entries", []):
+            items.append(
+                SearchResult(
+                    uri=entry.get("uri", ""),
+                    name=entry.get("name", ""),
+                    description=entry.get("description"),
+                    tags=entry.get("tags", []),
+                    schema_ref=entry.get("schemaRef"),
+                    source="atmosphere",
+                    record=entry,
+                )
+            )
+
+        return SearchResults(
+            items=items,
+            cursor=result.get("cursor"),
+            total_hint=None,
+            source="atmosphere",
+        )
+
+    def health_check(self) -> bool:
+        """Check AppView reachability via ``describeService``."""
+        try:
+            from atdata.atmosphere._types import LEXICON_NAMESPACE
+
+            self._atmo.xrpc_query(f"{LEXICON_NAMESPACE}.describeService")
+            return True
+        except Exception:
+            return False
+
+
+# ------------------------------------------------------------------ #
+# Local search backend
+# ------------------------------------------------------------------ #
+
+
+class LocalSearchBackend:
+    """Search backend for the local index.
+
+    Searches ``LocalDatasetEntry`` records by substring matching on name
+    and filtering by tags and schema reference.  Does not require any
+    external services.
+
+    Args:
+        index: An ``Index`` instance.
+
+    Examples:
+        >>> from atdata import Index
+        >>> index = Index()
+        >>> backend = LocalSearchBackend(index)
+        >>> results = backend.search(text="train")
+    """
+
+    def __init__(self, index: Any) -> None:
+        self._index = index
+
+    @property
+    def name(self) -> str:
+        """Backend identifier."""
+        return "local"
+
+    def search(
+        self,
+        text: str | None = None,
+        tags: list[str] | None = None,
+        schema_ref: str | None = None,
+        repo: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SearchResults:
+        """Search local index entries by name substring and metadata filters.
+
+        Args:
+            text: Substring to match against entry names (case-insensitive).
+            tags: Filter by tags stored in entry metadata.
+            schema_ref: Filter by schema reference.
+            repo: Ignored for local search (local entries have no repo DID).
+            limit: Maximum results.
+            cursor: Offset-based pagination cursor (stringified integer).
+
+        Returns:
+            ``SearchResults`` with locally-sourced items.
+        """
+        offset = int(cursor) if cursor else 0
+
+        matched: list[SearchResult] = []
+        text_lower = text.lower() if text else None
+
+        for entry in self._index.datasets:
+            # Text filter: substring match on name
+            if text_lower is not None and text_lower not in entry.name.lower():
+                continue
+
+            # Schema filter
+            if schema_ref is not None and entry.schema_ref != schema_ref:
+                continue
+
+            # Tag filter: check entry metadata for tags
+            entry_tags: list[str] = []
+            if entry.metadata and isinstance(entry.metadata.get("tags"), list):
+                entry_tags = entry.metadata["tags"]
+
+            if tags is not None:
+                if not all(t in entry_tags for t in tags):
+                    continue
+
+            matched.append(
+                SearchResult(
+                    uri=entry.cid,
+                    name=entry.name,
+                    description=(
+                        entry.metadata.get("description") if entry.metadata else None
+                    ),
+                    tags=entry_tags,
+                    schema_ref=entry.schema_ref,
+                    source="local",
+                )
+            )
+
+        # Apply offset-based pagination
+        total = len(matched)
+        page = matched[offset : offset + limit]
+        next_cursor = str(offset + limit) if offset + limit < total else None
+
+        return SearchResults(
+            items=page,
+            cursor=next_cursor,
+            total_hint=total,
+            source="local",
+        )
+
+    def health_check(self) -> bool:
+        """Local backend is always available."""
+        return True
+
+
+# ------------------------------------------------------------------ #
+# Search aggregator
+# ------------------------------------------------------------------ #
+
+
+class SearchAggregator:
+    """Aggregates and deduplicates results from multiple search backends.
+
+    Results are collected from every healthy backend, deduplicated by URI,
+    and returned as a single ``SearchResults``. When a dataset appears in
+    multiple backends the first occurrence is kept (backends are tried in
+    the order given).
+
+    Args:
+        backends: Ordered list of search backends to query.
+
+    Examples:
+        >>> agg = SearchAggregator([local_backend, appview_backend])
+        >>> results = agg.search(text="mnist")
+    """
+
+    def __init__(self, backends: list[SearchBackend]) -> None:
+        self._backends = backends
+
+    def search(
+        self,
+        text: str | None = None,
+        tags: list[str] | None = None,
+        schema_ref: str | None = None,
+        repo: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SearchResults:
+        """Query all healthy backends and return deduplicated results.
+
+        Args:
+            text: Free-text query string.
+            tags: Filter by tags.
+            schema_ref: Filter by schema reference.
+            repo: Filter by repository DID or handle.
+            limit: Maximum total results returned.
+            cursor: Not used by the aggregator (each backend may paginate
+                independently).
+
+        Returns:
+            ``SearchResults`` with items from all backends, deduplicated
+            by URI and name.
+        """
+        log = get_logger()
+        all_items: list[SearchResult] = []
+
+        for backend in self._backends:
+            if not backend.health_check():
+                log.warning(
+                    "Search backend %s failed health check, skipping", backend.name
+                )
+                continue
+            try:
+                results = backend.search(
+                    text=text,
+                    tags=tags,
+                    schema_ref=schema_ref,
+                    repo=repo,
+                    limit=limit,
+                )
+                all_items.extend(results.items)
+            except Exception:
+                log.warning(
+                    "Search backend %s raised an exception, skipping",
+                    backend.name,
+                    exc_info=True,
+                )
+
+        deduplicated = _deduplicate(all_items)
+
+        # Sort: scored results first (descending), then alphabetical by name
+        deduplicated.sort(key=lambda r: (r.score is None, -(r.score or 0), r.name))
+
+        # Apply global limit
+        page = deduplicated[:limit]
+
+        return SearchResults(
+            items=page,
+            cursor=None,
+            total_hint=len(deduplicated),
+            source="aggregated",
+        )
+
+
+def _deduplicate(items: list[SearchResult]) -> list[SearchResult]:
+    """Remove duplicate results, keeping the first occurrence.
+
+    Deduplication keys:
+    1. By URI (exact match).
+    2. By name (case-insensitive) — a dataset named "mnist" from local
+       and atmosphere should appear only once.
+    """
+    seen_uris: set[str] = set()
+    seen_names: set[str] = set()
+    unique: list[SearchResult] = []
+
+    for item in items:
+        if item.uri in seen_uris:
+            continue
+        name_key = item.name.lower()
+        if name_key in seen_names:
+            continue
+        seen_uris.add(item.uri)
+        seen_names.add(name_key)
+        unique.append(item)
+
+    return unique

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,708 @@
+"""Tests for the unified search API (search.py and Index.search).
+
+Covers:
+- SearchResult and SearchResults dataclass construction
+- AppViewSearchBackend with mocked xrpc_query
+- LocalSearchBackend with a real SQLite-backed Index
+- SearchAggregator deduplication and sorting
+- Index.search() end-to-end with both backends
+- Graceful degradation when AppView is unavailable
+- Edge cases: empty results, pagination, backend failures
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+import atdata
+from atdata.search import (
+    SearchResult,
+    SearchResults,
+    SearchBackend,
+    AppViewSearchBackend,
+    LocalSearchBackend,
+    SearchAggregator,
+    _deduplicate,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sqlite_index(tmp_path):
+    """Index backed by a temp SQLite database with sample data."""
+    from atdata.stores._disk import LocalDiskStore
+
+    store = LocalDiskStore(root=tmp_path / "data")
+    index = atdata.Index(
+        provider="sqlite",
+        path=str(tmp_path / "index.db"),
+        data_store=store,
+        atmosphere=None,
+    )
+    return index
+
+
+@pytest.fixture
+def populated_index(sqlite_index, tmp_path):
+    """Index with several datasets already written."""
+
+    @atdata.packable
+    class SearchSample:
+        name: str
+        value: int
+
+    samples_a = [SearchSample(name=f"a-{i}", value=i) for i in range(5)]
+    samples_b = [SearchSample(name=f"b-{i}", value=i) for i in range(5)]
+    samples_c = [SearchSample(name=f"c-{i}", value=i) for i in range(5)]
+
+    sqlite_index.write_samples(
+        samples_a,
+        name="mnist-train",
+        metadata={"tags": ["vision", "digits"], "description": "MNIST training set"},
+    )
+    sqlite_index.write_samples(
+        samples_b,
+        name="mnist-test",
+        metadata={"tags": ["vision", "digits"], "description": "MNIST test set"},
+    )
+    sqlite_index.write_samples(
+        samples_c,
+        name="cifar-train",
+        metadata={"tags": ["vision", "objects"], "description": "CIFAR training set"},
+    )
+
+    return sqlite_index
+
+
+@pytest.fixture
+def mock_atmosphere():
+    """Mocked Atmosphere client with AppView."""
+    atmo = Mock()
+    atmo.has_appview = True
+    atmo.xrpc_query.return_value = {
+        "entries": [
+            {
+                "uri": "at://did:plc:abc/science.alt.dataset.entry/tid1",
+                "name": "genomics-v1",
+                "description": "Genomics dataset",
+                "tags": ["bio", "genomics"],
+                "schemaRef": "at://did:plc:abc/science.alt.dataset.schema/s1",
+            },
+            {
+                "uri": "at://did:plc:abc/science.alt.dataset.entry/tid2",
+                "name": "proteomics-v1",
+                "description": "Proteomics dataset",
+                "tags": ["bio", "proteomics"],
+                "schemaRef": None,
+            },
+        ],
+        "cursor": "next-page-token",
+    }
+    return atmo
+
+
+# =============================================================================
+# SearchResult / SearchResults dataclass tests
+# =============================================================================
+
+
+class TestSearchResult:
+    def test_minimal_construction(self):
+        r = SearchResult(uri="cid:abc", name="test")
+        assert r.uri == "cid:abc"
+        assert r.name == "test"
+        assert r.description is None
+        assert r.tags == []
+        assert r.schema_ref is None
+        assert r.source == "unknown"
+        assert r.score is None
+        assert r.record is None
+
+    def test_full_construction(self):
+        r = SearchResult(
+            uri="at://did:plc:x/science.alt.dataset.entry/y",
+            name="mnist",
+            description="Hand-written digits",
+            tags=["vision"],
+            schema_ref="at://did:plc:x/science.alt.dataset.schema/z",
+            source="atmosphere",
+            score=0.95,
+            record={"raw": True},
+        )
+        assert r.score == 0.95
+        assert r.tags == ["vision"]
+        assert r.record == {"raw": True}
+
+    def test_default_tags_not_shared(self):
+        """Each instance gets its own tags list."""
+        a = SearchResult(uri="a", name="a")
+        b = SearchResult(uri="b", name="b")
+        a.tags.append("x")
+        assert b.tags == []
+
+
+class TestSearchResults:
+    def test_empty(self):
+        r = SearchResults()
+        assert r.items == []
+        assert r.cursor is None
+        assert r.total_hint is None
+        assert r.source == "unknown"
+
+    def test_with_items(self):
+        items = [SearchResult(uri="1", name="one"), SearchResult(uri="2", name="two")]
+        r = SearchResults(items=items, cursor="abc", total_hint=100, source="local")
+        assert len(r.items) == 2
+        assert r.cursor == "abc"
+        assert r.total_hint == 100
+
+
+# =============================================================================
+# SearchBackend protocol compliance
+# =============================================================================
+
+
+class TestSearchBackendProtocol:
+    def test_appview_backend_satisfies_protocol(self):
+        backend = AppViewSearchBackend(Mock())
+        assert isinstance(backend, SearchBackend)
+
+    def test_local_backend_satisfies_protocol(self):
+        backend = LocalSearchBackend(Mock())
+        assert isinstance(backend, SearchBackend)
+
+    def test_custom_backend_satisfies_protocol(self):
+        """A third-party class satisfying the protocol is recognized."""
+
+        class CustomBackend:
+            @property
+            def name(self) -> str:
+                return "custom"
+
+            def search(
+                self,
+                text=None,
+                tags=None,
+                schema_ref=None,
+                repo=None,
+                limit=50,
+                cursor=None,
+            ):
+                return SearchResults(source="custom")
+
+            def health_check(self) -> bool:
+                return True
+
+        assert isinstance(CustomBackend(), SearchBackend)
+
+
+# =============================================================================
+# AppViewSearchBackend
+# =============================================================================
+
+
+class TestAppViewSearchBackend:
+    def test_search_returns_results(self, mock_atmosphere):
+        backend = AppViewSearchBackend(mock_atmosphere)
+        results = backend.search(text="genomics")
+
+        assert results.source == "atmosphere"
+        assert len(results.items) == 2
+        assert results.items[0].name == "genomics-v1"
+        assert results.items[0].source == "atmosphere"
+        assert results.items[0].tags == ["bio", "genomics"]
+        assert results.cursor == "next-page-token"
+
+    def test_search_passes_params(self, mock_atmosphere):
+        backend = AppViewSearchBackend(mock_atmosphere)
+        backend.search(
+            text="test",
+            tags=["bio"],
+            schema_ref="at://x/y/z",
+            repo="did:plc:abc",
+            limit=10,
+            cursor="prev",
+        )
+
+        mock_atmosphere.xrpc_query.assert_called_once()
+        call_args = mock_atmosphere.xrpc_query.call_args
+        params = call_args[1]["params"] if "params" in call_args[1] else call_args[0][1]
+        assert params["q"] == "test"
+        assert params["tags"] == ["bio"]
+        assert params["schemaRef"] == "at://x/y/z"
+        assert params["repo"] == "did:plc:abc"
+        assert params["limit"] == 10
+        assert params["cursor"] == "prev"
+
+    def test_search_limit_capped_at_100(self, mock_atmosphere):
+        backend = AppViewSearchBackend(mock_atmosphere)
+        backend.search(limit=200)
+
+        call_args = mock_atmosphere.xrpc_query.call_args
+        params = call_args[1]["params"] if "params" in call_args[1] else call_args[0][1]
+        assert params["limit"] == 100
+
+    def test_search_no_text_omits_q_param(self, mock_atmosphere):
+        backend = AppViewSearchBackend(mock_atmosphere)
+        backend.search()
+
+        call_args = mock_atmosphere.xrpc_query.call_args
+        params = call_args[1]["params"] if "params" in call_args[1] else call_args[0][1]
+        assert "q" not in params
+
+    def test_search_empty_response(self):
+        atmo = Mock()
+        atmo.xrpc_query.return_value = {"entries": []}
+        backend = AppViewSearchBackend(atmo)
+        results = backend.search(text="nothing")
+        assert results.items == []
+        assert results.cursor is None
+
+    def test_health_check_success(self):
+        atmo = Mock()
+        atmo.xrpc_query.return_value = {"did": "did:web:test"}
+        backend = AppViewSearchBackend(atmo)
+        assert backend.health_check() is True
+
+    def test_health_check_failure(self):
+        atmo = Mock()
+        atmo.xrpc_query.side_effect = Exception("unreachable")
+        backend = AppViewSearchBackend(atmo)
+        assert backend.health_check() is False
+
+    def test_name_property(self, mock_atmosphere):
+        backend = AppViewSearchBackend(mock_atmosphere)
+        assert backend.name == "atmosphere"
+
+
+# =============================================================================
+# LocalSearchBackend
+# =============================================================================
+
+
+class TestLocalSearchBackend:
+    def test_search_by_text(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(text="mnist")
+
+        assert results.source == "local"
+        assert len(results.items) == 2
+        names = {r.name for r in results.items}
+        assert names == {"mnist-train", "mnist-test"}
+
+    def test_search_case_insensitive(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(text="MNIST")
+        assert len(results.items) == 2
+
+    def test_search_by_tags(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(tags=["digits"])
+
+        assert len(results.items) == 2
+        for r in results.items:
+            assert "digits" in r.tags
+
+    def test_search_by_multiple_tags(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(tags=["vision", "objects"])
+
+        assert len(results.items) == 1
+        assert results.items[0].name == "cifar-train"
+
+    def test_search_by_schema_ref(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        # Get actual schema ref from an entry
+        entries = populated_index.list_entries()
+        ref = entries[0].schema_ref
+
+        results = backend.search(schema_ref=ref)
+        # All entries share the same schema
+        assert len(results.items) == 3
+
+    def test_search_combined_text_and_tags(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(text="mnist", tags=["digits"])
+        assert len(results.items) == 2
+
+    def test_search_no_matches(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(text="nonexistent")
+        assert results.items == []
+        assert results.total_hint == 0
+
+    def test_search_no_filters_returns_all(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search()
+        assert len(results.items) == 3
+
+    def test_search_limit(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(limit=2)
+        assert len(results.items) == 2
+        assert results.cursor is not None  # more results available
+
+    def test_search_pagination(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+
+        page1 = backend.search(limit=2)
+        assert len(page1.items) == 2
+        assert page1.cursor is not None
+
+        page2 = backend.search(limit=2, cursor=page1.cursor)
+        assert len(page2.items) == 1
+        assert page2.cursor is None  # no more results
+
+        # Pages should not overlap
+        page1_names = {r.name for r in page1.items}
+        page2_names = {r.name for r in page2.items}
+        assert page1_names.isdisjoint(page2_names)
+
+    def test_search_description_from_metadata(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        results = backend.search(text="mnist-train")
+        assert len(results.items) == 1
+        assert results.items[0].description == "MNIST training set"
+
+    def test_health_check_always_true(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        assert backend.health_check() is True
+
+    def test_name_property(self, populated_index):
+        backend = LocalSearchBackend(populated_index)
+        assert backend.name == "local"
+
+    def test_search_empty_index(self, sqlite_index):
+        backend = LocalSearchBackend(sqlite_index)
+        results = backend.search(text="anything")
+        assert results.items == []
+
+
+# =============================================================================
+# Deduplication
+# =============================================================================
+
+
+class TestDeduplication:
+    def test_dedup_by_uri(self):
+        items = [
+            SearchResult(uri="abc", name="dataset-a", source="local"),
+            SearchResult(uri="abc", name="dataset-a-dup", source="atmosphere"),
+        ]
+        result = _deduplicate(items)
+        assert len(result) == 1
+        assert result[0].source == "local"  # first occurrence kept
+
+    def test_dedup_by_name_case_insensitive(self):
+        items = [
+            SearchResult(uri="local-1", name="MNIST", source="local"),
+            SearchResult(uri="at://x/y/z", name="mnist", source="atmosphere"),
+        ]
+        result = _deduplicate(items)
+        assert len(result) == 1
+        assert result[0].source == "local"
+
+    def test_dedup_preserves_order(self):
+        items = [
+            SearchResult(uri="1", name="alpha"),
+            SearchResult(uri="2", name="beta"),
+            SearchResult(uri="3", name="gamma"),
+        ]
+        result = _deduplicate(items)
+        assert [r.name for r in result] == ["alpha", "beta", "gamma"]
+
+    def test_dedup_empty_list(self):
+        assert _deduplicate([]) == []
+
+    def test_dedup_all_unique(self):
+        items = [
+            SearchResult(uri="a", name="one"),
+            SearchResult(uri="b", name="two"),
+            SearchResult(uri="c", name="three"),
+        ]
+        result = _deduplicate(items)
+        assert len(result) == 3
+
+
+# =============================================================================
+# SearchAggregator
+# =============================================================================
+
+
+class TestSearchAggregator:
+    def test_aggregates_multiple_backends(self):
+        local = Mock(spec=["name", "search", "health_check"])
+        local.name = "local"
+        local.health_check.return_value = True
+        local.search.return_value = SearchResults(
+            items=[SearchResult(uri="local-1", name="ds-local", source="local")],
+            source="local",
+        )
+
+        remote = Mock(spec=["name", "search", "health_check"])
+        remote.name = "atmosphere"
+        remote.health_check.return_value = True
+        remote.search.return_value = SearchResults(
+            items=[SearchResult(uri="at://x", name="ds-remote", source="atmosphere")],
+            source="atmosphere",
+        )
+
+        agg = SearchAggregator([local, remote])
+        results = agg.search(text="ds")
+
+        assert results.source == "aggregated"
+        assert len(results.items) == 2
+
+    def test_deduplicates_across_backends(self):
+        local = Mock(spec=["name", "search", "health_check"])
+        local.name = "local"
+        local.health_check.return_value = True
+        local.search.return_value = SearchResults(
+            items=[SearchResult(uri="local-1", name="mnist", source="local")],
+            source="local",
+        )
+
+        remote = Mock(spec=["name", "search", "health_check"])
+        remote.name = "atmosphere"
+        remote.health_check.return_value = True
+        remote.search.return_value = SearchResults(
+            items=[SearchResult(uri="at://x", name="MNIST", source="atmosphere")],
+            source="atmosphere",
+        )
+
+        agg = SearchAggregator([local, remote])
+        results = agg.search(text="mnist")
+
+        assert len(results.items) == 1
+        assert results.items[0].source == "local"  # local listed first
+
+    def test_skips_unhealthy_backend(self):
+        healthy = Mock(spec=["name", "search", "health_check"])
+        healthy.name = "local"
+        healthy.health_check.return_value = True
+        healthy.search.return_value = SearchResults(
+            items=[SearchResult(uri="1", name="ok", source="local")],
+            source="local",
+        )
+
+        unhealthy = Mock(spec=["name", "search", "health_check"])
+        unhealthy.name = "atmosphere"
+        unhealthy.health_check.return_value = False
+
+        agg = SearchAggregator([healthy, unhealthy])
+        results = agg.search(text="test")
+
+        assert len(results.items) == 1
+        unhealthy.search.assert_not_called()
+
+    def test_handles_backend_exception(self):
+        ok = Mock(spec=["name", "search", "health_check"])
+        ok.name = "local"
+        ok.health_check.return_value = True
+        ok.search.return_value = SearchResults(
+            items=[SearchResult(uri="1", name="ok", source="local")],
+            source="local",
+        )
+
+        broken = Mock(spec=["name", "search", "health_check"])
+        broken.name = "broken"
+        broken.health_check.return_value = True
+        broken.search.side_effect = RuntimeError("boom")
+
+        agg = SearchAggregator([ok, broken])
+        results = agg.search(text="test")
+
+        assert len(results.items) == 1
+        assert results.items[0].name == "ok"
+
+    def test_applies_global_limit(self):
+        backend = Mock(spec=["name", "search", "health_check"])
+        backend.name = "local"
+        backend.health_check.return_value = True
+        backend.search.return_value = SearchResults(
+            items=[
+                SearchResult(uri=str(i), name=f"ds-{i}", source="local")
+                for i in range(20)
+            ],
+            source="local",
+        )
+
+        agg = SearchAggregator([backend])
+        results = agg.search(limit=5)
+        assert len(results.items) == 5
+
+    def test_sorts_scored_results_first(self):
+        backend = Mock(spec=["name", "search", "health_check"])
+        backend.name = "mixed"
+        backend.health_check.return_value = True
+        backend.search.return_value = SearchResults(
+            items=[
+                SearchResult(uri="1", name="unscored", source="local", score=None),
+                SearchResult(uri="2", name="low-score", source="atmo", score=0.3),
+                SearchResult(uri="3", name="high-score", source="atmo", score=0.9),
+            ],
+            source="mixed",
+        )
+
+        agg = SearchAggregator([backend])
+        results = agg.search()
+
+        assert results.items[0].name == "high-score"
+        assert results.items[1].name == "low-score"
+        assert results.items[2].name == "unscored"
+
+    def test_no_backends(self):
+        agg = SearchAggregator([])
+        results = agg.search(text="anything")
+        assert results.items == []
+        assert results.source == "aggregated"
+
+
+# =============================================================================
+# Index.search() integration
+# =============================================================================
+
+
+class TestIndexSearch:
+    def test_local_only_search(self, populated_index):
+        results = populated_index.search(text="mnist")
+        assert len(results.items) == 2
+        assert all(r.source == "local" for r in results.items)
+
+    def test_search_with_no_atmosphere(self, populated_index):
+        """Index with atmosphere=None still searches local."""
+        results = populated_index.search(text="cifar")
+        assert len(results.items) == 1
+        assert results.items[0].name == "cifar-train"
+
+    def test_search_include_atmosphere_false(self, populated_index):
+        results = populated_index.search(text="mnist", include_atmosphere=False)
+        assert len(results.items) == 2
+        assert all(r.source == "local" for r in results.items)
+
+    def test_search_returns_search_results_type(self, populated_index):
+        results = populated_index.search()
+        assert isinstance(results, SearchResults)
+        for item in results.items:
+            assert isinstance(item, SearchResult)
+
+    def test_search_empty_query(self, populated_index):
+        """No filters returns all datasets."""
+        results = populated_index.search()
+        assert len(results.items) == 3
+
+    def test_search_by_tags(self, populated_index):
+        results = populated_index.search(tags=["objects"])
+        assert len(results.items) == 1
+        assert results.items[0].name == "cifar-train"
+
+    def test_search_limit(self, populated_index):
+        results = populated_index.search(limit=1)
+        assert len(results.items) == 1
+
+    def test_search_no_results(self, populated_index):
+        results = populated_index.search(text="nonexistent-dataset")
+        assert results.items == []
+
+    def test_search_with_atmosphere_appview(self, tmp_path):
+        """Index.search includes atmosphere when appview is configured."""
+        index = atdata.Index(
+            provider="sqlite",
+            path=str(tmp_path / "index.db"),
+            atmosphere=None,
+        )
+
+        # Mock the atmosphere backend
+        mock_atmo_backend = Mock()
+        mock_client = Mock()
+        mock_client.has_appview = True
+        mock_client.xrpc_query.return_value = {
+            "entries": [
+                {
+                    "uri": "at://did:plc:x/science.alt.dataset.entry/t1",
+                    "name": "remote-ds",
+                    "tags": [],
+                }
+            ],
+            "cursor": None,
+        }
+        mock_atmo_backend.client = mock_client
+        index._atmosphere = mock_atmo_backend
+        index._atmosphere_deferred = False
+
+        results = index.search(text="remote")
+        assert any(r.source == "atmosphere" for r in results.items)
+
+    def test_search_graceful_degradation(self, tmp_path):
+        """If atmosphere health check fails, search still returns local results."""
+
+        @atdata.packable
+        class S:
+            name: str
+            value: int
+
+        store = atdata.LocalDiskStore(root=tmp_path / "data")
+        index = atdata.Index(
+            provider="sqlite",
+            path=str(tmp_path / "index.db"),
+            data_store=store,
+            atmosphere=None,
+        )
+        index.write_samples(
+            [S(name="x", value=1)],
+            name="local-ds",
+        )
+
+        # Set up a broken atmosphere backend
+        mock_atmo_backend = Mock()
+        mock_client = Mock()
+        mock_client.has_appview = True
+        mock_client.xrpc_query.side_effect = ConnectionError("offline")
+        mock_atmo_backend.client = mock_client
+        index._atmosphere = mock_atmo_backend
+        index._atmosphere_deferred = False
+
+        results = index.search(text="local")
+        assert len(results.items) == 1
+        assert results.items[0].source == "local"
+
+
+# =============================================================================
+# Public API exports
+# =============================================================================
+
+
+class TestExports:
+    def test_search_result_importable(self):
+        from atdata import SearchResult as SR
+
+        assert SR is SearchResult
+
+    def test_search_results_importable(self):
+        from atdata import SearchResults as SRs
+
+        assert SRs is SearchResults
+
+    def test_search_backend_importable(self):
+        from atdata import SearchBackend as SB
+
+        assert SB is SearchBackend
+
+    def test_appview_search_backend_importable(self):
+        from atdata import AppViewSearchBackend as ASB
+
+        assert ASB is AppViewSearchBackend
+
+    def test_local_search_backend_importable(self):
+        from atdata import LocalSearchBackend as LSB
+
+        assert LSB is LocalSearchBackend
+
+    def test_search_aggregator_importable(self):
+        from atdata import SearchAggregator as SA
+
+        assert SA is SearchAggregator


### PR DESCRIPTION
## Summary

- Adds `SearchBackend` protocol for pluggable search providers, with `AppViewSearchBackend` (atmosphere XRPC) and `LocalSearchBackend` (SQLite index) implementations
- Adds `SearchAggregator` for combining and deduplicating results across multiple backends with graceful degradation
- Adds `Index.search()` method that aggregates local + atmosphere search with a single call
- Exports `SearchResult`, `SearchResults`, `SearchBackend` from `atdata` public API

Closes #37

## Test plan

- [x] 58 new tests in `test_search.py` covering all backends, aggregator deduplication, edge cases, and `Index.search()` integration
- [x] All 1781 tests pass (0 failures)
- [x] Lint clean (`ruff check` + `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)